### PR TITLE
[slack-web-api.js] Fix the protocol error when loading the test report

### DIFF
--- a/tests/common/slack-web-api.js
+++ b/tests/common/slack-web-api.js
@@ -27,7 +27,7 @@ module.exports = async (reportData, capability) => {
         width: 860,
         height: 1060
     });
-    await page.goto(path.resolve(htmlPath));
+    await page.goto("file://" + path.resolve(htmlPath));
     await page.evaluate(() => {
         location.hash = 'page=report';
         window.postMessage({


### PR DESCRIPTION
Hi @cenfun,

There's an error in **tests/common/slack-web-api.js**, when load the generated report in the local folder, we need to prepend **file://** to the path, otherwise, a protocol error will be thrown. 

Thanks,
Alex