### PR TITLE
fix: Resolve relative root to '.'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+* Unreleased
+  - fixed relative path resolution (#196)
+
 * 2.11.2
   - updated metadata and annotations
 

--- a/lib/utils/util.js
+++ b/lib/utils/util.js
@@ -22,6 +22,9 @@ const Util = {
         root = `${root || Util.root}`;
         let rp = path.relative(root, p);
         rp = Util.formatPath(rp);
+        if (rp === '') {
+            return '.';
+        }
         return rp;
     },
 


### PR DESCRIPTION
**Problem**
`Util.relativePath()` currently resolves the project root to '' when relative. This causes confusion in produced reports, as readers will see the path as blank, making them question whether there was an error during generation. It may also lead to incorrect path resolution given string concatenation.

**Motivation**
[Playwright-BDD](https://github.com/vitalets/playwright-bdd) generates `.feature.spec.js` files according to their file structure as children of `testDir`. This means that if there is a feature in `tests/` and `testDir` is also `tests/`, the spec will be saved in `tests/tests/`. In order to save specs in the same location as features, `testDir` must be '.'.

**Fix**
In `lib\utils\util.js`, an if statement has been added to `Util.relativePath` that returns '.' if `rp` is empty. The change requires rebuilding.

**Coverage**
This change was tested by setting `testDir` in `tests/playwright.config.js` to '..' and opening the 'report' page in produced reports. The Test Dir label in the Timeline row will correctly read 'Test Dir .', and remain this way after clicking and copying it.

**Caveat**
`relAssetsDir` in `lib/assets.js`, if it resolves to '.', may cause the later \<script\> to point to a non-existent path (e.g., 'index.html/script.js'). This is likely a minor issue, as the default behaviour is for report assets to be stored in the `assets/` subfolder.