### PR TITLE
feat: Alert for trace viewer when not online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+* Unreleased
+  - updated trace viewer help style (#198)
+
 * 2.11.3
   - fixed relative path resolution (#196)
 

--- a/packages/app/src/components/detail/attachments/trace.vue
+++ b/packages/app/src/components/detail/attachments/trace.vue
@@ -38,6 +38,8 @@ onMounted(() => {
     d.protocol = window.location.protocol;
     const isOnline = ['http:', 'https:'].includes(d.protocol);
 
+    d.icon = isOnline ? 'help' : 'error';
+    d.iconStyle = isOnline ? '' : 'color: var(--color-flaky);';
     d.color = isOnline ? 'color: green;' : 'color: red;';
 
     const { path } = props.data;
@@ -63,6 +65,11 @@ onMounted(() => {
         target="_blank"
       >View trace</a>
     </VuiFlex>
+    <IconLabel
+      :icon="d.icon"
+      :style="d.iconStyle"
+      @click="showTraceHelp"
+    />
     <VuiFlex gap="3px">
       <IconLabel icon="download" />
       <a
@@ -71,10 +78,6 @@ onMounted(() => {
         target="_blank"
       >Download</a>
     </VuiFlex>
-    <IconLabel
-      icon="help"
-      @click="showTraceHelp"
-    />
   </div>
 </template>
 

--- a/packages/app/src/components/icon-label.vue
+++ b/packages/app/src/components/icon-label.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {
-    computed, onMounted, ref, useSlots, watch
+    computed, nextTick, onMounted, ref, useSlots, watch
 } from 'vue';
 
 import { decodeIcons } from '../common/common.js';
@@ -95,9 +95,16 @@ const showIcon = () => {
     if (!svg) {
         return;
     }
-    const $el = el.value;
 
-    $el.innerHTML = svg;
+    const setSvg = () => {
+        if (el.value) {
+            el.value.innerHTML = svg;
+        }
+    };
+    if (!el.value) {
+        return nextTick(setSvg);
+    }
+    setSvg();
 };
 
 onMounted(() => {


### PR DESCRIPTION
**Motivation**
When first using this reporter, I tried opening the trace viewer through the provided test links and was presented with the obtuse error message 'Trace Viewer uses Service Workers to show traces.' It took me longer than expected to realise that I had to look at the info tooltip to the right of the Download button to see why I couldn't use the link. Therefore, I want to reduce this initial friction for other first-time users.

**Feature**
- In `packages\app\src\components\detail\attachments\trace.vue`, the 'showTraceHelp' `IconLabel` has been moved to immediately after the 'View trace' link. Additionally, its icon and colour will change if the report is being viewed as a file, changing to the error icon (⚠️) with the flaky colour, so that it is more likely to be clicked first.
- The dynamic icon and colour adjustment above does not work properly without the necessary changes to `packages\app\src\components\icon-label.vue`, wrapping `el.value.innerHTML = svg;` in a function that is run on `nextTick()`. If these changes aren't made, the icon is missing from the resulting HTML.

**Coverage**
This change was tested each time by rebuilding the package, re-running a collection of its provided tests and inspecting individual tests that display a lot of information, checking instances where the icon starts hidden out of view.

**Caveat**
There was no suitable dynamic icon for this feature other than the error icon (⚠️), but this may create confusion as it could be misinterpreted as an error. My recommendation is to add a separate icon called 'error' (e.g., 🛑), and to rename the current error icon to 'warning'.