### PR TITLE
Style and word wrap test metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+* Unreleased
+  - feat: style and word wrap test metadata (#201)
+
 * 2.12.1
   - feat: collapse attachments (switch to collapse/expand all attachments)
   - support copyAttachments disabled when outputDir is same as testOutputDir (attachments are already in place)

--- a/packages/app/src/components/detail/detail-simple-list.vue
+++ b/packages/app/src/components/detail/detail-simple-list.vue
@@ -28,11 +28,24 @@ const props = defineProps({
 
 <style lang="scss">
 .mcr-simple-column {
+    align-items: flex-start;
     min-width: 20px;
+    max-width: 100%;
+    margin-left: auto;
     padding: 2px 6px;
     font-size: 13px;
     border: 1px solid #ddd;
     border-radius: 5px;
     background-color: rgb(175 184 193 / 20%);
+
+    > div:first-child {
+        font-weight: bold;
+    }
+
+    > div:last-child {
+        flex-shrink: 1;
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
 }
 </style>


### PR DESCRIPTION
**Motivation**
For individual tests, large text present in their metadata chips is not displayed in full as it is forced not to overflow. This is especially problematic for long URLs, which ought to be seen in full. In addition, their metadata chips aren't styled like project metadata, and their alignment changes from right to left if there are too many chips. This pull request rectifies both problems.

**Feature**
In `packages/app/src/components/detail/detail-simple-list.vue`, the `.mcr-simple-column` styling has been updated to include:
- `max-width: 100%` so metadata chips respect container boundaries
- `margin-left: auto` so metadata chips stay aligned right even when pushed onto subsequent lines
- `align-items: flex-start` so metadata keys are aligned to the top when values grow large
- `font-weight: bold` for first child div so metadata keys are highlighted
- `flex-shrink: 1; white-space: normal; overflow-wrap: anywhere;` for last child div so metadata values wrap onto multiple lines, even when their text is overly long (new line characters are ignored when displayed, reduces total used height)

**Coverage**
This change was tested by editing the metadata in `tests\data\data.spec.js` and `tests\playwright.config.js` to add a new key. It was tested with long sentences, medium-sized URLs (e.g., `https://raw.githubusercontent.com/cenfun/monocart-reporter/refs/heads/main/tests/data/data.spec.js`) and long URLs.

**Caveats**
- Excessively large metadata values (e.g., JSON dumps) will take up a large amount of space, and there are currently no measures in place to protect from this. Personally, I would recommend making metadata values scrollable with a hidden scrollbar, indicated by a soft gradient at the bottom of chips after a certain number of lines.
- Metadata keys do not wrap and create a similar problem when they are too long, but this considered a non-issue, since they are present as column names and are also an eyesore in that context if they are too long.