### PR TITLE
fix: Escape HTML characters in titles and step names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+* Unreleased
+  - fixed HTML injection in titles and step names (#203)
+
 * 2.12.2
   - feat: style and word wrap test metadata (#201)
   - fixed tooltip overflow and positioning

--- a/packages/app/src/components/detail/detail-info.vue
+++ b/packages/app/src/components/detail/detail-info.vue
@@ -62,9 +62,7 @@ onMounted(() => {
 
     if (rowItem.type === 'step') {
         // step
-        if (rowItem.stepType === 'retry') {
-            data.html = rowItem.title;
-        }
+        data.html = Util.quoteAttr(rowItem.title);
         return;
     }
 

--- a/packages/app/src/modules/formatters.js
+++ b/packages/app/src/modules/formatters.js
@@ -159,7 +159,7 @@ const tagsFormatter = (tags) => {
 };
 
 const titleTagsFormatter = (rowItem, columnItem) => {
-    const title = rowItem.title;
+    const title = Util.quoteAttr(rowItem.title);
 
     if (columnItem && columnItem.titleTagsDisabled) {
         return title;


### PR DESCRIPTION
**Problem**
HTML characters in titles and step names are not sanitised, leading to HTML injection. This is an issue when a step name needs to include an element name, e.g. "<input>".

**Fix**
In `packages\app\src\components\detail\detail-info.vue` and `packages\app\src\modules\formatters.js`, `rowItem.title` has been changed to `Util.quoteAttr(rowItem.title)` on specific lines to escape only test-provided text.

**Coverage**
This change was tested by using HTML characters in `tests\data\data.spec.js`, ensuring that no HTML generated by the report is unintentionally escaped.

**Caveat**
Only titles and step names are escaped. It is possible that other kinds of text used in the report ought to be escaped.