### PR TITLE
feat: New search parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+* Unreleased
+  - feat: new search parser (#204)
+
 * 2.12.3
   - fixed HTML injection in titles and step names (#203)
 

--- a/packages/app/src/app.vue
+++ b/packages/app/src/app.vue
@@ -659,12 +659,14 @@ window.addEventListener('popstate', microtask(() => {
     const caseType = hash.get('caseType');
     state.caseType = caseType || 'tests';
 
-    // Restore tags from hash
-    const tags = hash.get('tags');
-    if (tags) {
-        state.keywords = tags.split(',').map((t) => `@${t.trim()}`).filter((t) => t !== '@').join(' ');
-    } else {
-        state.keywords = '';
+    // Restore tags from hash (only if search input is not focused)
+    if (!state.searchHelperTarget) {
+        const tags = hash.get('tags');
+        if (tags) {
+            state.keywords = tags.split(',').map((t) => `@${t.trim()}`).filter((t) => t !== '@').join(' ');
+        } else {
+            state.keywords = '';
+        }
     }
 
     displayFlyoverWithHash();

--- a/packages/app/src/modules/grid.js
+++ b/packages/app/src/modules/grid.js
@@ -386,6 +386,27 @@ const getRowNumberFilter = () => {
     };
 };
 
+/*
+- Keywords separated by spaces
+- Double quotes create single keywords with spaces (inner quotes escaped with \)
+- Leading hyphen negates the keyword
+- All keywords are case-insensitive
+*/
+const parseKeywords = (keywords) => {
+    const parsed = [];
+    if (!keywords) {
+        return parsed;
+    }
+    const regex = /(?<=^|\s)(-?)(?:"((?:.(?:\\")?)+?)"|([^\s]+))(?=\s|$)/g;
+    let match;
+    while ((match = regex.exec(keywords))) {
+        parsed.push({
+            text: (match[2]?.replace(/\\"/g, '"') ?? match[3]).toLowerCase(),
+            negate: match[1] === '-'
+        });
+    }
+    return parsed;
+};
 
 const getGridSortComparers = () => {
     return {
@@ -450,13 +471,22 @@ const getGridOption = () => {
             }
         },
         rowFilter: function(rowItem) {
-
             const searchableAllKeys = state.searchableAllKeys;
-
-            const hasMatched = this.highlightKeywordsFilter(rowItem, searchableAllKeys, state.keywords);
-
-            return hasMatched;
-
+            let text = '';
+            for (const key of searchableAllKeys) {
+                text = `${text} ${String(rowItem[key]).replace(/[\t\r\n]+/g, ' ')}`;
+            }
+            text = text.toLowerCase();
+            const keywords = parseKeywords(state.keywords);
+            for (const keyword of keywords) {
+                if (
+                    (!keyword.negate && !text.includes(keyword.text))
+                    || (keyword.negate && text.includes(keyword.text))
+                ) {
+                    return false;
+                }
+            }
+            return true;
         },
         rowNotFound: '<div class="mcr-no-results">No Results</div>',
         frozenColumn: 1,


### PR DESCRIPTION
**Motivation**
When a report has a lot of test cases, it can become difficult to filter to a subset of them, especially when that subset has complex conditions. Below is a list of complex report searches that are impossible with the current implementation:
- Filtering by multiple conditions (e.g., 'TestSource @ tag')
- Negating the appearance of a tag (e.g., '-@ smoke')

**Feature**
- In `packages\app\src\modules\grid.js`:
  - `parseKeywords()` has been added, which takes `keywords` as a string and uses a regular expression to convert it into a list of objects with properties `{ text: string; negate: boolean; }`. This process obeys the following rules:
    - Keywords separated by spaces
    - Double quotes create single keywords with spaces (inner quotes escaped with \\)
    - Leading hyphen negates the keyword
    - All keywords are case-insensitive
  - `getGridOption().rowFilter()` has been updated to filter row items using the conditions specified by the parsed keyword objects. `this.highlightKeywordsFilter()` has been removed from the function, as it is legacy behaviour.
- In `packages\app\src\app.vue`, `window.addEventListener('popstate')` now only restores tags from hash if the search input is not focused, preventing instances where a complex search query being manually typed is automatically sanitised (potentially modifying the query).

**Coverage**
This change was tested each time by rebuilding the package, re-running all of the provided tests and typing various complex search queries.

**Caveat**
Since `this.highlightKeywordsFilter()` was removed from `getGridOption().rowFilter()`, matching text in row items is not highlighted. This functionality was not possible for me to easily re-implement, as `highlightKeywordsFilter()` is seemingly not defined anywhere in this package. The legacy behaviour can be restored by re-adding the offending function without returning its value.