### PR TITLE
feat: Support tag styling by regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+* Unreleased
+  - feat: tag styling by regular expressions (#205)
+
 * 2.12.3
   - fixed HTML injection in titles and step names (#203)
 

--- a/README.md
+++ b/README.md
@@ -545,6 +545,9 @@ module.exports = {
                 },
                 critical: {
                     background: '#c00'
+                },
+                '/^feature(:|$)/': {
+                    background: '#0066CC'
                 }
             }
         }]

--- a/lib/common.js
+++ b/lib/common.js
@@ -38,11 +38,33 @@ const stepHandler = (item, summary) => {
 // all tags for global report
 const tagHandler = (item, tags, tagOptions) => {
 
+    const getTagOptions = (tag) => {
+        if (tagOptions[tag]) {
+            return tagOptions[tag];
+        }
+        for (const regexStr in tagOptions) {
+            if (typeof regexStr !== 'string' || !regexStr.startsWith('/') || regexStr.lastIndexOf('/') === 0) {
+                continue;
+            }
+            try {
+                const lastSlashIndex = regexStr.lastIndexOf('/');
+                const pattern = regexStr.substring(1, lastSlashIndex);
+                const flags = regexStr.substring(lastSlashIndex + 1);
+                const regex = new RegExp(pattern, flags);
+                if (regex.test(tag)) {
+                    return tagOptions[regexStr];
+                }
+            } catch (e) {
+                // Skip invalid regex patterns
+            }
+        }
+    };
+
     const addTag = (tag) => {
         let tagItem = tags[tag];
         if (!tagItem) {
             tagItem = {};
-            const options = tagOptions[tag];
+            const options = getTagOptions(tag);
             if (options) {
                 if (options.style) {
                     Object.assign(tagItem, options);

--- a/lib/default/options.js
+++ b/lib/default/options.js
@@ -59,6 +59,9 @@ module.exports = () => ({
     //     },
     //     sanity: {
     //         'background': '#178F43'
+    //     },
+    //     '/^feature(:|$)/': {
+    //         'background': '#0066CC'
     //     }
     // },
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -138,6 +138,9 @@ export type MonocartReporterOptions = {
      *   },
      *   sanity: {
      *     'background': '#178F43'
+     *   },
+     *   '/^feature(:|$)/': {
+     *     'background': '#0066CC'
      *   }
      * }
      * ```

--- a/tests/example/example.spec.js
+++ b/tests/example/example.spec.js
@@ -481,7 +481,7 @@ test.describe('next group', () => {
 
 test.describe('new syntax for tag and annotation in playwright v1.42.0', {
     // tag all tests in a group
-    tag: '@report',
+    tag: ['@feature:annotations', '@feature:tags', '@report'],
     // annotate all tests in a group
     annotation: {
         type: 'category', description: 'report'

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -271,7 +271,10 @@ module.exports = {
                 critical: {
                     background: '#c00'
                 },
-                slow: 'background:orange;'
+                '/^(slow|flaky)$/': 'background:orange;',
+                '/^feature(:|$)/': {
+                    background: '#0066CC'
+                }
             },
 
             // custom columns


### PR DESCRIPTION
**Motivation**
In the Playwright tests that I find myself running, there are multiple tags which are in the format '@<tag>:<reason>', and I want to be able to style all of them without duplicating code. This reporter currently doesn't support styling multiple tags at once, requiring all tags to be identified with strict string keys. Therefore, I have created this pull request to add support for regular expression strings to the `tags` property in the reporter's options.

**Feature**
- `README.md`, `lib\default\options.js` and `lib\index.d.ts` have been updated with an example of how to use regular expressions in the `tags` property.
- `lib\common.js` has been modified to add the function `tagHandler().getTagOptions()`, which first searches for a strict string match, then parses each `tags` property key as a regular expression if it is in the format '/expression/flags'.
- `tests\example\example.spec.js` has been modified to include new '@ feature:' tags that will be styled via regular expressions.
- `tests\playwright.config.js` has been modified to update the existing 'slow' styling to be a regular expression that also covers 'flaky', and add the example regular expression styling.

**Coverage**
This change was tested each time by rebuilding the package, re-running all of the provided tests and viewing the resulting reports.

**Caveat**
There are potential performance improvements that could be made in `tagHandler().getTagOptions()`.